### PR TITLE
(build) Pin to specific version of Cake.Recipe

### DIFF
--- a/setup.cake
+++ b/setup.cake
@@ -1,4 +1,4 @@
-#load nuget:https://www.myget.org/F/cake-contrib/api/v2?package=Cake.Recipe&prerelease
+#load nuget:?package=Cake.Recipe&version=1.0.0
 
 Environment.SetVariableNames();
 


### PR DESCRIPTION
There are some breaking changes coming in Cake.Recipe, and the recommendation is
to pin to the official released version of Cake.Recipe until all the breaking changes are 
completed.